### PR TITLE
Fix character encoding for exported JSON

### DIFF
--- a/app/controllers/ListingExporter.java
+++ b/app/controllers/ListingExporter.java
@@ -19,7 +19,7 @@ public class ListingExporter extends Controller {
     private static final S3Uploader draftUploader = new S3Uploader(String.valueOf(Play.configuration.get("s3.draft.export.bucket.name")));
 
     private final static int EXPORT_PAGE_SIZE = 500;
-    
+
     public static void exportCompletedListingsAsJson() {
 
         Queue queue = QueueFactory.getDefaultQueue();
@@ -30,7 +30,7 @@ public class ListingExporter extends Controller {
         }
         ok();
     }
-    
+
     public static void paginatedExport(String cursor) {
         Queue queue = QueueFactory.getDefaultQueue();
         String dateString = DocumentUtils.dateString();
@@ -93,8 +93,14 @@ public class ListingExporter extends Controller {
             return;
         }
         String listingJSON = ListingToJSONConverter.convertToJson(listing);
+        byte[] listingBytes;
+        try {
+            listingBytes = listingJSON.getBytes("UTF-8");
+        } catch (java.io.UnsupportedEncodingException ex) {
+            listingBytes = listingJSON.getBytes();
+        }
         String documentKey = String.format("%s/%s/%s", date, listing.supplierId, DocumentUtils.s3ExportFilename(listing.id));
-        String documentUrl = uploader.upload(listingJSON.getBytes(), documentKey);
+        String documentUrl = uploader.upload(listingBytes, documentKey);
         Logger.info(String.format("Uploaded listing to: %s", documentUrl));
     }
 }


### PR DESCRIPTION
Should have specified "UTF-8" for conversion to byte array in the first place.

Fixes this bug: https://www.pivotaltracker.com/story/show/86292728

Tested locally and exported a bunch of special characters just fine; export pasted below:

{
   "id":2,
   "supplierId":1,
   "lot":"SCS",
   "title":"My — Long Dashed – En dashes service",
   "lastUpdated":"2015-01-16T11:52:04Z",
   "lastUpdatedByEmail":"supplier@digital.cabinet-office.gov.uk",
   "lastCompleted":"2015-01-16T11:52:09Z",
   "lastCompletedByEmail":"supplier@digital.cabinet-office.gov.uk",
   "serviceTypes":[
      "Implementation",
      "Ongoing support",
      "Planning"
   ],
   "serviceName":"My — Long Dashed – En dashes service",
   "serviceSummary":"We really ❤ to charge you £££s for our 5★ service!",
   "serviceBenefits":[
      "Benefit 1"
   ],
   "serviceFeatures":[
      "Feat 1"
   ],
   "priceInterval":"",
   "priceUnit":"User",
   "educationPricing":true,
   "vatIncluded":false,
   "priceString":"£10 to £20 per user",
   "priceMax":20,
   "pricingDocument":"Poster_MJ_s_Charity_Concert_WLC.pdf",
   "priceMin":10,
   "pricingDocumentURL":"https://s3-eu-west-1.amazonaws.com/gds-g6-submission-bucket-local/1/2/2-pricing-document.pdf",
   "supportForThirdParties":false,
   "supportAvailability":"By frosty ☃☃☃",
   "supportResponseTime":"3 days",
   "incidentEscalation":false,
   "supportTypes":[
      "Service desk",
      "Email"
   ],
   "vendorCertifications":[

   ],
   "serviceDefinitionDocument":"Poster_MJ_s_Charity_Concert_WLC.pdf",
   "serviceDefinitionDocumentURL":"https://s3-eu-west-1.amazonaws.com/gds-g6-submission-bucket-local/1/2/2-service-definition-document.pdf",
   "termsAndConditionsDocument":"Poster_MJ_s_Charity_Concert_WLC.pdf",
   "minimumContractPeriod":"Day",
   "terminationCost":true,
   "termsAndConditionsDocumentURL":"https://s3-eu-west-1.amazonaws.com/gds-g6-submission-bucket-local/1/2/2-terms-and-condtions.pdf"
}